### PR TITLE
adds app-ads.txt file

### DIFF
--- a/app-ads.txt
+++ b/app-ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-4039429507317338, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
This PR introduces app-ads.txt file.

The app-ads.txt file is a standard created by the IAB Tech Lab (Interactive Advertising Bureau) to help prevent unauthorized or spoofed mobile app ad inventory sales. It is the mobile app equivalent of the ads.txt file used on websites.

🔍 What Is app-ads.txt?
app-ads.txt (Authorized Sellers for Apps) is a plain text file that mobile app developers host on their developer website domain. It lists the advertising platforms (e.g., AdMob, Facebook Audience Network) that are authorized to sell the app's ad inventory.

✅ Why It's Important
Prevents Ad Fraud: Stops unauthorized parties from falsely claiming to sell your ad inventory.

Increases Advertiser Trust: Advertisers prefer buying inventory from authorized sources.

May Impact Ad Revenue: Some demand sources may not serve ads if this file is missing or misconfigured.

